### PR TITLE
Netlify Deploy Status Badge is working

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Jekyll website template designed for Prep Fellows.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/97877b3e-9f36-4939-a24c-0b622f923d50/deploy-status)](https://app.netlify.com/sites/prep-22-p3-2/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/6d19c4e2-04ff-4671-b610-85d96cd600f3/deploy-status)](https://app.netlify.com/sites/prep-22-p3-2/deploys)
 
 
 ## Make your own!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Jekyll website template designed for Prep Fellows.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/97877b3e-9f36-4939-a24c-0b622f923d50/deploy-status)](https://app.netlify.com/sites/mlh-fellowship-portfolio/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/97877b3e-9f36-4939-a24c-0b622f923d50/deploy-status)](https://app.netlify.com/sites/prep-22-p3-2/deploys)
 
 
 ## Make your own!


### PR DESCRIPTION
There was a bug in the netlify status badge but now it's working. 

<img width="624" alt="image" src="https://user-images.githubusercontent.com/38958532/161922187-7e4658ba-5f33-4f79-b74e-bb90fba3ba66.png">


## What the PR is adding 

The PR edits the link for the netlify badge in the readme by updating the pod name and link. 

## Checks

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.

## Issues this closes
This closes #19 